### PR TITLE
Adding the possibility to use a third party milter without activating 

### DIFF
--- a/jylibs/serverconfig.py
+++ b/jylibs/serverconfig.py
@@ -137,12 +137,14 @@ class ServerConfig(config.Config):
 		if (self["zimbraMilterServerEnabled"] == "TRUE"):
 			milter = "inet:%s:%s" % (self["zimbraMilterBindAddress"],self["zimbraMilterBindPort"])
 		else:
-			self["zimbraMtaSmtpdMilters"] = ""
+			milter = None
 
 		if self["zimbraMtaSmtpdMilters"] is not None and milter is not None:
 			self["zimbraMtaSmtpdMilters"] = "%s, %s" % (self["zimbraMtaSmtpdMilters"], milter)
 		elif self["zimbraMtaSmtpdMilters"] is None and milter is not None:
 			self["zimbraMtaSmtpdMilters"] = milter
+                elif self["zimbraMtaSmtpdMilters"] is not None and milter is None:
+                        self["zimbraMtaSmtpdMilters"] = "%s, %s" % (self["zimbraMtaSmtpdMilters"])
 
 		if self["zimbraMtaHeaderChecks"] is not None:
 			v = self["zimbraMtaHeaderChecks"]


### PR DESCRIPTION
you can apply the patch and restart zmconfigctl.
before (Normal Behavior with Milter Zimbra Activated) :
$zmprov gs `zmhostname` zimbraMilterServerEnabled 
# name zimbra87.zimbra.lab
zimbraMilterServerEnabled: TRUE

$zmprov ms `zmhostname` zimbraMtaSmtpdMilters "inet:localhost:10000"

$zmprov gs `zmhostname` zimbraMtaSmtpdMilters
zimbraMtaSmtpdMilters: inet:localhost:10000, inet:127.0.0.1:7026
$zmconfigdctl restart
$postconf smtpd_milters
smtpd_milters = inet:localhost:10000, inet:127.0.0.1:7026

before (Normal Behavior without Milter Zimbra Activated) :
$zmprov gs `zmhostname` zimbraMilterServerEnabled 
# name zimbra87.zimbra.lab
zimbraMilterServerEnabled: FALSE

$zmprov ms `zmhostname` zimbraMtaSmtpdMilters "inet:localhost:10000"

$zmprov gs `zmhostname` zimbraMtaSmtpdMilters
zimbraMtaSmtpdMilters: inet:localhost:10000
$zmconfigdctl restart
$postconf smtpd_milters
smtpd_milters = 

after :
$zmprov gs `zmhostname` zimbraMilterServerEnabled 
# name zimbra87.zimbra.lab
zimbraMilterServerEnabled: FALSE

$zmprov gs `zmhostname` zimbraMtaSmtpdMilters
zimbraMtaSmtpdMilters: inet:localhost:10000

$postconf smtpd_milters
smtpd_milters = inet:localhost:10000