### PR TITLE
ZCS-11112: Changes as per log4j2.17

### DIFF
--- a/jylibs/commands.py
+++ b/jylibs/commands.py
@@ -17,7 +17,7 @@
 
 
 from logmsg import *
-from org.apache.log4j import PropertyConfigurator
+from org.apache.logging.log4j.core.config import Configurator
 import shlex
 import subprocess
 import time
@@ -62,7 +62,7 @@ exe = {
 	}
 
 class Command:
-	PropertyConfigurator.configure("/opt/zimbra/conf/zmconfigd.log4j.properties");
+	Configurator.initialize(None, "/opt/zimbra/conf/zmconfigd.log4j.properties");
 	P = Provisioning.getInstance(Provisioning.CacheMode.OFF)
 
 	@classmethod


### PR DESCRIPTION
**Issue:** Used log4j version was below 2.17.1

**Solution** Upgraded log4j version to 2.17.1 as well as did implementation for same.