### PR TITLE
ZBUG-3542:zimbra.log filled with command not defined for onlyoffice

### DIFF
--- a/jylibs/commands.py
+++ b/jylibs/commands.py
@@ -59,6 +59,9 @@ exe = {
 	'CONVERTD'      : "bin/zmconvertctl",
 	'OPENDKIM'	: "bin/zmopendkimctl",
 	'DNSCACHE'	: "bin/zmdnscachectl",
+        'LICENSE-DAEMON': "bin/zmlicensectl",
+        'ONLYOFFICE'    : "bin/zmonlyofficectl",
+        'NALPEIRON-DAEMON' : "bin/zmlicensectl",
 	}
 
 class Command:
@@ -481,6 +484,21 @@ commands = {
 		name = "convertd",
 		cmd  = exe["CONVERTD"] + " %s",
 	),
+        "license-daemon" : Command(
+                desc = "license-daemon",
+                name = "license-daemon",
+                cmd  = exe["LICENSE-DAEMON"] + " %s",
+        ),
+        "onlyoffice" : Command(
+                desc = "onlyoffice",
+                name = "onlyoffice",
+                cmd  = exe["ONLYOFFICE"] + " %s",
+        ),
+        "nalpeiron-daemon" : Command(
+                desc = "nalpeiron-daemon",
+                name = "nalpeiron-daemon",
+                cmd  = exe["NALPEIRON-DAEMON"] + " --nalpeiron %s",
+        ),
 	}
 
 miscCommands = ["garpu","garpb","gamcs","gamau"]

--- a/jylibs/commands.py
+++ b/jylibs/commands.py
@@ -487,7 +487,7 @@ commands = {
         "license-daemon" : Command(
                 desc = "license-daemon",
                 name = "license-daemon",
-                cmd  = exe["LICENSE-DAEMON"] + " %s",
+                cmd  = exe["LICENSE-DAEMON"] + " --service %s",
         ),
         "onlyoffice" : Command(
                 desc = "onlyoffice",


### PR DESCRIPTION
Added commands for **license-daemon**, **nalpeiron-daemon**, & **onlyoffice** in order to resolve issue of

1.  Command not defined for license-daemon

1.  Command not defined for nalpeiron-daemon

1.  Command not defined for onlyoffice

which gets observed in **zimbra.log**  
